### PR TITLE
Allow NPM installs, don't enforce Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "version": "standard-version",
     "reset": "git clean -dfx && git reset --hard && npm i",
     "clean": "trash build test",
-    "prepare-release": "run-s reset test cov:check doc:html version doc:publish",
-    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('casbin-mongo-adapter must be installed with Yarn: https://yarnpkg.com/')\""
+    "prepare-release": "run-s reset test cov:check doc:html version doc:publish"
   },
   "scripts-info": {
     "info": "Display information about the package scripts",
@@ -61,7 +60,8 @@
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
     "@types/mongodb": "^3.3.6",
     "@types/mongodb-memory-server": "^1.8.0",
-    "ava": "^2.4.0",
+    "@types/tmp": "^0.1.0",
+    "ava": "^3.0.0",
     "codecov": "^3.5.0",
     "cz-conventional-changelog": "^2.1.0",
     "gh-pages": "^2.0.1",


### PR DESCRIPTION
- Removed pre-install hook that enforced Yarn and did not allow NPM
- Updated the ava package as with the old version, the build would not
  work
- Added @types/npm as without, the build would not work