### PR TITLE
Packages Version Update: Casbin, MongoDB, tslint & Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "casbin-mongodb-adapter",
-  "version": "1.3.0",
-  "description": "Pure MongoDB adapter for Casbin",
+  "name": "casbin-mongodb-adapter-v2",
+  "version": "2.0.0",
+  "description": "Pure MongoDB adapter for Casbin Versions Update",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
   "module": "build/module/index.js",
-  "repository": "https://github.com/juicycleff/casbin-mongodb-adapter",
+  "repository": "https://github.com/juicycleff/casbin-mongodb-adapter-v2",
   "license": "MIT",
   "keywords": [],
   "scripts": {
@@ -65,11 +65,11 @@
     "@types/mongodb-memory-server": "^2.3.0",
     "@types/tmp": "^0.1.0",
     "ava": "^3.15.0",
-    "casbin": "^5.17.0",
+    "casbin": "^5.30.0",
     "codecov": "^3.8.1",
     "cz-conventional-changelog": "^3.3.0",
     "gh-pages": "^2.0.1",
-    "mongodb": "^4.9.0",
+    "mongodb": "^6.8.0",
     "mongodb-memory-server": "^8.9.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
@@ -80,7 +80,7 @@
     "tslint": "^5.18.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-immutable": "^6.0.1",
-    "typescript": "^3.5.3"
+    "typescript": "^5.5.3"
   },
   "ava": {
     "failFast": true,

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "casbin-mongodb-adapter-v2",
-  "version": "2.0.0",
-  "description": "Pure MongoDB adapter for Casbin Versions Update",
+  "name": "casbin-mongodb-adapter",
+  "version": "1.3.0",
+  "description": "Pure MongoDB adapter for Casbin",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
   "module": "build/module/index.js",
-  "repository": "https://github.com/juicycleff/casbin-mongodb-adapter-v2",
+  "repository": "https://github.com/juicycleff/casbin-mongodb-adapter",
   "license": "MIT",
   "keywords": [],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -77,10 +77,9 @@
     "prettier": "^1.18.2",
     "standard-version": "^6.0.1",
     "trash-cli": "^3.0.0",
-    "tslint": "^5.18.0",
+    "tslint": "^5.20.0",
     "tslint-config-prettier": "^1.18.0",
-    "tslint-immutable": "^6.0.1",
-    "typescript": "^5.5.3"
+    "typescript": "^5.6.2"
   },
   "ava": {
     "failFast": true,


### PR DESCRIPTION
Able to run build with following npm package changes: 
Casbin: 5.30.0,
MongoDB: 6.8.0,
Typescript: 5.6.2,
tslint: 5.20.0,
tslint-immutable: PACKAGE REMOVED